### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 
 .DS_Store
 /node_modules/
-
+/templates/public/bundle.js
 __pycache__/
+


### PR DESCRIPTION
Excludes the following:
- `/node_modules/` this is massive we don't want all the dependencies in github
- `/__pycache__/`
-`bundle.js` gets generated every time npm run commands occur